### PR TITLE
校车和路由部分

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@
 </script>
 
 <template>
- <router-view name="right"></router-view>
  <RouterView></RouterView>
 </template>
+
+

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1,5 +1,5 @@
 <template>
-  <n-menu :options="menuOptions" default-value="school-bus-time"/>
+  <n-menu :options="menuOptions"/>
 </template>
 
 <script setup lang="ts">
@@ -14,7 +14,7 @@ import {
 import { RouterLink } from "vue-router"
 
 
-function renderIcon(icon: Component) {
+function renderIcon (icon: Component) {
   return () => h(NIcon, null, { default: () => h(icon) })
 }
 

--- a/src/components/Top.vue
+++ b/src/components/Top.vue
@@ -5,11 +5,13 @@ import {
   LogInOutline as LogInIcon
 } from "@vicons/ionicons5";
 import { useRouter } from "vue-router";
+import { useUserStore } from "../store";
 
 const router = useRouter();
+const userStore = useUserStore();
 
 const handleLogout = () => {
-  window.localStorage.setItem("isLogin", "false");
+  userStore.logout();
   router.push("/login");
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,10 +1,11 @@
-import { createApp,h } from 'vue'
-import App from './App.vue'
+import { createApp } from "vue"
+import App from "./App.vue"
 import naive from "naive-ui";
-import router from './routers'
-import pinia from "./store/store"
+import router from "./routers"
+import pinia from "./store"
+
 const app = createApp(App);
 app.use(naive);
 app.use(router);
 app.use(pinia);
-app.mount('#app');
+app.mount("#app");

--- a/src/pages/Login.vue
+++ b/src/pages/Login.vue
@@ -1,19 +1,16 @@
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
-import { canUserAccess } from "../utils/canUserAccess";
 import { NInput, NH1, NSpace, NButton, NForm, NFormItem } from "naive-ui";
 import loginAPI from "../apis/UserAPI/login";
+import { useUserStore } from "../store";
 import { useRouter } from "vue-router";
 
+const userStore = useUserStore();
 const router = useRouter();
 
-onMounted(async () => {
-  const isLogin = localStorage.getItem("isLogin");
-  if (isLogin === "true") {
-    const state = await canUserAccess();
-    if (state === true) router.push({
-      path: "/"
-    })
+onMounted(() => {
+  if (localStorage.getItem("passTime")) {
+    router.push("/");
   }
 })
 
@@ -27,7 +24,7 @@ const handleLogin = async () => {
       password: password.value
     });
     if (res.code === 1) {
-      localStorage.setItem("isLogin", "true");
+      userStore.login(res.data.user);
       router.push("/");
     } else {
       throw new Error(res.msg);

--- a/src/pages/SchoolBus.vue
+++ b/src/pages/SchoolBus.vue
@@ -17,7 +17,7 @@ const {
   loading 
 } = useRequest(BusServices.getCurrentLinesAPI, {
   onSuccess: (data) => {
-    if (data.code !== 200)
+    if (data.code !== 1)
       throw new Error(data.msg);
   },
   onError: (e) => {

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -4,57 +4,83 @@ import TermTime from "../components/TermTime.vue";
 import Announcement from "../pages/Announcement.vue";
 import Layout from "../pages/Layout.vue";
 import { createRouter, createWebHistory } from "vue-router";
-import { canUserAccess } from "../utils/canUserAccess";
+import { useUserStore } from "../store";
+import getUserInfoAPI from "../apis/UserAPI/getUserInfo";
 
 const routes = [
   {
     path: "/login",
     name: "Login",
+    meta: {
+      requestAuth: false,
+    },
     component: Login,
   },
   {
     path: "/",
     name: "Layout",
+    meta: {
+      requestAuth: true,
+    },
     component: Layout,
     children: [
       {
         path: "schoolbus",
         name: "SchoolBus",
-        component: SchoolBus,
-      },
-      {
-        path: "schoolbus",
-        name: "SchoolBus",
+        meta: {
+          requestAuth: true,
+        },
         component: SchoolBus,
       },
       {
         path: "termtime",
         name: "TermTime",
+        meta: {
+          requestAuth: true,
+        },
         component: TermTime,
       },
       {
         path: "announcement",
         name: "Announcement",
+        meta: {
+          requestAuth: true,
+        },
         component: Announcement,
       },
-    ],
+    ]
   },
-];
+]
 
 const router = createRouter({
   history: createWebHistory(),
-  routes,
-});
+  routes
+})
 
 router.beforeEach(async (to) => {
-  if (to.name !== "Login") {
-    const isLoginInStore = window.localStorage.getItem("isLogin");
-    const res = await canUserAccess();
-    if (!res || isLoginInStore !== "true") {
-      window.localStorage.setItem("isLogin", "false");
-      return "/login"
+  if (to.meta.requestAuth) {
+    const userStore = useUserStore();
+    if (!userStore.userInfo) {
+      try {
+        if (!localStorage.getItem("passTime")) return "/login";
+        // 先检查是否超过7日未登陆
+        const lastLoginTime = Number.parseInt(localStorage.getItem("passTime") || "0");
+        if (new Date().getTime() - lastLoginTime > 1000 * 60 * 60 * 24 * 7) {
+          throw new Error("登陆过期")
+        }
+
+        // 请求并写入用户信息
+        const { data, code, msg } = await getUserInfoAPI();
+        if (code === 1) {
+          userStore.login(data.user);
+        } else throw new Error(msg);
+      } catch (e: any) {
+        console.log(`自动登陆状态失败, ${e.message || "未知错误"}`)
+        userStore.logout();
+        return "/login";
+      }
     }
   }
-});
+})
 
 export default router;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,8 +1,10 @@
-import { defineStore } from "pinia";
-import { ref } from "vue";
+import { createPinia } from "pinia";
+import useUserStore from "./useUserStore";
 
-export const useLoginStore = defineStore("login", () => {
-  const isLogin = ref(false);
+const pinia = createPinia();
 
-  return { isLogin };
-});
+export default pinia;
+
+export {
+  useUserStore
+}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,3 +1,0 @@
-import { createPinia } from 'pinia';
-const pinia = createPinia();
-export default pinia;

--- a/src/store/useUserStore.ts
+++ b/src/store/useUserStore.ts
@@ -1,0 +1,31 @@
+import { defineStore } from "pinia"
+import { ref } from "vue"
+
+export default defineStore("user", () => {
+  const userInfo = ref<UserAPI.User>();
+
+  /**
+   * 登陆
+   * @param user 用户信息
+   * 更新用户信息以及登陆时间
+   */
+  const login = (user: UserAPI.User) => {
+    userInfo.value = user;
+    localStorage.setItem("passTime", new Date().getTime().toString());
+  }
+
+  /**
+   * 登出
+   * 删除用户信息以及上次登陆时间
+   */
+  const logout = () => {
+    userInfo.value = undefined;
+    localStorage.removeItem("passTime");    
+  }
+
+  return { 
+    userInfo,
+    login,
+    logout
+  }
+})


### PR DESCRIPTION
1.完成登录状态持久化，现在的登录有效期是7天
2.现在app中只有1个router-view，展示顶栏和菜单，右侧内容的router-view在layout中展示
3.直接进根路由会优先跳转至layout界面（如果已经登录的话）
4.所有菜单功能相关的路由均已改成二级路由，位于一级路由layout之下
5.注销切换路由的同时，清空localstorage数据
6.登录成功时，生成登录状态对象数据，储存在localstorage中，每次跳转时先检查是否有未过期的登录数据，再决定跳转位置
7.废弃了原先校车页面的方案，现在的校车页面写法与通知一致